### PR TITLE
add getGuiScreen() to GuiManager

### DIFF
--- a/src/org/darkstorm/minecraft/gui/AbstractGuiManager.java
+++ b/src/org/darkstorm/minecraft/gui/AbstractGuiManager.java
@@ -27,8 +27,11 @@ package org.darkstorm.minecraft.gui;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import net.minecraft.client.gui.GuiScreen;
+
 import org.darkstorm.minecraft.gui.component.Frame;
 import org.darkstorm.minecraft.gui.theme.Theme;
+import org.darkstorm.minecraft.gui.util.GuiManagerDisplayScreen;
 
 /**
  * Minecraft GUI API
@@ -104,5 +107,10 @@ public abstract class AbstractGuiManager implements GuiManager {
 		Frame[] frames = getFrames();
 		for(int i = frames.length - 1; i >= 0; i--)
 			frames[i].update();
+	}
+
+	@Override
+	public GuiScreen getGuiScreen() {
+		return new GuiManagerDisplayScreen(this);
 	}
 }

--- a/src/org/darkstorm/minecraft/gui/GuiManager.java
+++ b/src/org/darkstorm/minecraft/gui/GuiManager.java
@@ -24,6 +24,8 @@
  */
 package org.darkstorm.minecraft.gui;
 
+import net.minecraft.client.gui.GuiScreen;
+
 import org.darkstorm.minecraft.gui.component.Frame;
 import org.darkstorm.minecraft.gui.theme.Theme;
 
@@ -52,4 +54,6 @@ public interface GuiManager {
 	public void renderPinned();
 
 	public void update();
+
+	public GuiScreen getGuiScreen();
 }


### PR DESCRIPTION
I thought this would make the API a bit cleaner while still leaving the option for multiple GuiScreen implementations. `mc.displayGuiScreen(manager.getGuiScreen());` instead of `mc.displayGuiScreen(new GuiManagerDisplayScreen(manager));`.
